### PR TITLE
Prevent SDRP from triggering Incompatible FML Modded Server message.

### DIFF
--- a/src/main/java/com/sunekaer/mods/sdrp/SDRP.java
+++ b/src/main/java/com/sunekaer/mods/sdrp/SDRP.java
@@ -12,11 +12,14 @@ import net.minecraftforge.client.event.GuiScreenEvent.InitGuiEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,6 +29,7 @@ public class SDRP {
     public static final Logger LOGGER = LogManager.getLogger("Simple Discord Rich Presence");
 
     public SDRP() {
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
             ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Config.configSpec);
             FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);


### PR DESCRIPTION
Client-sided mods should register as client-only as per:
https://mcforge.readthedocs.io/en/1.15.x/concepts/sides/#writing-one-sided-mods
to prevent them triggering the "Incompatible FML Modded Server" error on the Multiplayer menu.

Without this code they are required on the server as well for that error to be removed, which isn't ideal.